### PR TITLE
Pretty-print AI Agent tool-selection debug steps

### DIFF
--- a/src/components/content-ai-agents/utils/debug-step.ts
+++ b/src/components/content-ai-agents/utils/debug-step.ts
@@ -44,6 +44,7 @@ const STEP_KIND_LABELS: Record<string, string> = {
   text: 'Assistant Response',
   thinking: 'System / Thinking',
   tool_call: 'Tool Call',
+  'tool-selection': 'Tool Selection',
 };
 
 // Values longer than this get their own collapsed block instead of an inline row.
@@ -118,6 +119,17 @@ export const formatCompactStepValue = (value: unknown): string => {
  * Single-line excerpt used as a step's collapsed subtitle.
  */
 export const getStepPreview = (step: DebugStep): string => {
+  if ('tool-selection' === step.type) {
+    const agent = 'string' === typeof step.agentType ? step.agentType : '';
+    const mode = 'string' === typeof step.toolSelectionMode ? step.toolSelectionMode : '';
+    const catalogSize = 'number' === typeof step.catalogSize ? step.catalogSize : null;
+    const boundCount = Array.isArray(step.toolNames) ? step.toolNames.length : null;
+
+    if (agent && mode && null !== catalogSize && null !== boundCount) {
+      return `${agent} · ${mode} ${boundCount}/${catalogSize}`;
+    }
+  }
+
   const candidates = [step.content, step.goal, step.argsPreview, step.status];
   const source = candidates.find(
     candidate => 'string' === typeof candidate && Boolean(candidate.trim()),


### PR DESCRIPTION
## Summary
- Label `tool-selection` assistant steps as **Tool Selection** in the Execution tab.
- Collapsed preview uses structured bind fields when present: `module · subset 11/52` (falls back to step content).

Companion Divi stack layer: https://github.com/elegantthemes/submodule-builder-5/pull/9986
Issue: https://github.com/elegantthemes/Divi/issues/51734

## Test plan
- [ ] Check out builder-5 PR 9986 on top of the AI Agent stack.
- [ ] Prompt `Change this background to purple` in Visual Builder.
- [ ] Open d5-dev-tool AI Agent Execution tab.
- [ ] Confirm a **Tool Selection** step with preview `module · subset N/52` or `module · full N/N`.
- [ ] Expand the step and confirm `toolNames` / `catalogSize` / `toolSelectionMode` fields.